### PR TITLE
fix: SPM-26, view staff role skill match backend endpoint bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/ambv/black
-    rev: 23.10.0
+    rev: 23.10.1
     hooks:
       - id: black
         language_version: python3.9

--- a/api/routers/staff.py
+++ b/api/routers/staff.py
@@ -417,7 +417,7 @@ async def get_staff_role_listing_skills_match(
                         "ss_status": "active"
                     }
                 ],
-                "in-progress": [
+                "in_progress": [
                     {
                         "skill_id": 345678790,
                         "skill_name": "Typescript Developer",

--- a/database/schemas.py
+++ b/database/schemas.py
@@ -54,10 +54,17 @@ class SkillDetailsPydantic(BaseModel):
         orm_mode = True
 
 
+class StaffSkillDetailsPydantic(SkillDetailsPydantic):
+    ss_status: VerificationStatusEnum
+
+    class Config:
+        orm_mode = True
+
+
 class MatchStatus(BaseModel):
-    active: List[SkillDetailsPydantic] = []
-    in_progress: List[SkillDetailsPydantic] = []
-    unverified: List[SkillDetailsPydantic] = []
+    active: List[StaffSkillDetailsPydantic] = []
+    in_progress: List[StaffSkillDetailsPydantic] = []
+    unverified: List[StaffSkillDetailsPydantic] = []
 
     class Config:
         orm_mode = True

--- a/database/services.py
+++ b/database/services.py
@@ -268,7 +268,7 @@ def get_staff_role_skills_match(staff_id: int, role_listing_id: int):
         result = {
             "match": {
                 "active": [],
-                "in-progress": [],
+                "in_progress": [],
                 "unverified": [],
             },
             "missing": [],
@@ -297,9 +297,13 @@ def get_staff_role_skills_match(staff_id: int, role_listing_id: int):
                     "skill_status": skill.skill_status,
                     "ss_status": matching_staff_skill.ss_status,
                 }
-                result["match"][matching_staff_skill.ss_status].append(
-                    match_object
-                )
+                # Python does not allow '-' in variable names, thus in-progress has to be handled separately
+                if matching_staff_skill.ss_status == "in-progress":
+                    result["match"]["in_progress"].append(match_object)
+                else:
+                    result["match"][matching_staff_skill.ss_status].append(
+                        match_object
+                    )
             else:
                 mismatch_object = {
                     "skill_id": role_skill.skill_id,


### PR DESCRIPTION
https://linear.app/smu-spm/issue/SPM-26/apply-for-role

This PR fixes a bug in the backend endpoint that returns the match and mismatch of skills between a staff and a role listing, particularly the edge case for storing skills that were in the "in-progress" stage, previously this was not mapped correctly due to the '-' used here.

-   [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
-   [x] I've requested reviews from 1-2 reviewers
-   [ ] I've added/updated unit tests
-   [ ] I've added/updated e2e tests
-   [ ] I've added documentation in README/[Linear](insertlinkhere.com)
